### PR TITLE
socsec: Define type_lookup for 1030A0

### DIFF
--- a/socsec.py
+++ b/socsec.py
@@ -1225,7 +1225,7 @@ class SecureBootVerify(object):
                            0x8: RSA_OEM,
                            0xa: RSA_SOC_PUB,
                            0xe: RSA_SOC_PRI}
-        elif info_struct['version'] in ['A1', 'A2']:
+        elif info_struct['version'] in ['A1', 'A2', '1030A0' ]:
             type_lookup = {0x1: AES_VAULT,
                            0x2: AES_OEM,
                            0x8: RSA_OEM,
@@ -1244,6 +1244,7 @@ class SecureBootVerify(object):
                                0x8: RSA_OEM,
                                0xa: RSA_SOC_PUB,
                                0xc: RSA_SOC_PRI}
+
         key_list = []
         find_last = 0
         for i in range(16):


### PR DESCRIPTION
Patch cd51098c2436 ("socsec: add A3 RSA big endian key header") reworked the
`else` branch of the type_lookup assignment to an `elif`, dropping the
assignment of type_lookup for the 1030A0. This failure lead to the following
error:

```
$ ./socsec verify \
	--soc 1030 \
	--sec_image tests/data/generated/1030-a0_mode2aes2-rsa4096-sha512_rsa-priv/bl1.signed.bin \
	--output tests/data/generated/1030-a0_mode2aes2-rsa4096-sha512_rsa-priv/bl1.bin \
	--otp_image tests/data/generated/1030-a0_mode2aes2-rsa4096-sha512_rsa-priv/otp-all.image
Algorithm: AES_RSA_SHA
RSA length: 4096
HASH length: 512
1030A0
Traceback (most recent call last):
  File "./socsec", line 1733, in <module>
    tool.run(sys.argv)
  File "./socsec", line 1689, in run
    args.func(args)
  File "./socsec", line 1723, in verify_secure_image
    self.verify.verify_secure_image(args.soc,
  File "./socsec", line 1474, in verify_secure_image
    key_list = self.parse_data(info_struct, alg_data, data_region,
  File "./socsec", line 1258, in parse_data
    kl['TYPE'] = type_lookup[(h >> 14) & 0xf]
UnboundLocalError: local variable 'type_lookup' referenced before assignment
```

Restore the original behaviour by adding '1030A0' to the the 2600 A1/A2 path.

Fixes: cd51098c2436 ("socsec: add A3 RSA big endian key header")
Signed-off-by: Andrew Jeffery <andrew@aj.id.au>