### PR TITLE
ast2600: Allow for SPL as large as 64Kb - 512b

### DIFF
--- a/tools/resocsec
+++ b/tools/resocsec
@@ -54,6 +54,7 @@ def secure_bootloader_mode2(args):
                               None, # Chain-of-trust digest
                               args.sign_stream,
                               args.sign_file,
+                              args.stack_intersects_verification_region,
                               args.deterministic)
 
 def secure_bootloader_mode2aes1(args):
@@ -76,6 +77,7 @@ def secure_bootloader_mode2aes1(args):
                               None, # Chain-of-trust digest
                               args.sign_stream,
                               args.sign_file,
+                              args.stack_intersects_verification_region,
                               args.deterministic)
 
 def secure_bootloader_mode2aes2(args):
@@ -98,6 +100,7 @@ def secure_bootloader_mode2aes2(args):
                               None, # Chain-of-trust digest
                               args.sign_stream,
                               args.sign_file,
+                              args.stack_intersects_verification_region,
                               args.deterministic)
 
 def secure_bootloader_modegcm(args):
@@ -120,12 +123,14 @@ def secure_bootloader_modegcm(args):
                               None, # Chain-of-trust digest
                               args.sign_stream,
                               args.sign_file,
+                              args.stack_intersects_verification_region,
                               args.deterministic)
 
 def resocsec():
     parser = argparse.ArgumentParser(description="Really Easy SOCSEC!")
 
-    subparsers = parser.add_subparsers(title='socsec utilities')
+    subparsers = parser.add_subparsers(title='socsec utilities',
+                                       dest='subparser_name')
 
     bl1 = subparsers.add_parser('secure-bootloader',
                help='Make a signed (and optionally encrypted) bootloader image')
@@ -140,7 +145,23 @@ def resocsec():
                      help='Root-of-Trust header offset')
     bl1.add_argument('--sign-stream', help="Helper for signing via stdio")
     bl1.add_argument('--sign-file', help="Helper for signing files")
-
+    stack_intersects_verification_region_help='''By default, the
+    maximum size of SPL images socsec will sign is 60KB, since,
+    historically, the SoCs have been using the top of the SRAM
+    for the SPL execution stack. However, on 2600 (A1) and above
+    SoCs, an additional 24KB SRAM can be used for the stack,
+    allowing the verification region to occuppy the entire 64KB
+    (including signature). For these models of boards, this
+    layout will also be the default in future SDK releases.
+    Use this parameter to explicitly indicate that the SPL image
+    being signed has (=true) or has not (=false) the SPL stack
+    overlapping the 64KB verification region. With this argument
+    set to \'false\', socsec will sign SPL images up towards
+    64KB (including 512B signature)'''
+    sub_parser.add_argument('--stack-intersects-verification-region',
+                            dest='stack_intersects_verification_region',
+                            choices=['true', 'false'], default=None,
+                            help=stack_intersects_verification_region_help)
     schemes = bl1.add_subparsers(title='Secure-boot modes')
 
     # Mode 2
@@ -233,6 +254,10 @@ def resocsec():
 
     if 'func' in args:
         args.func(args)
+        if (args.subparser_name == 'secure-bootloader' and
+                args.stack_intersects_verification_region is None):
+            print('WARNING: --stack-intersects-verification-region={true|false} '
+                  'must be specified to ensure forwards compatibility.')
     else:
         parser.print_help()
 


### PR DESCRIPTION
Recent changes[1] to the Aspeed U-boot allows for the SPL image to
occupy the entire 64KB parity-checked SRAM.

[1] - AspeedTech-BMC/u-boot@a62cf9f

This patch adds a --spl_extra_sram argument to socsec and
resocsec that allows the max BL1 image size to occupy 64KB
(including signature) in case these type of images are being
used.

(Based on code originally from @amboar )