### PR TITLE
fix openssl command line when verifying with public key.

### DIFF
--- a/socsec/socsec.py
+++ b/socsec/socsec.py
@@ -342,7 +342,7 @@ def rsa_raw_ver(alg_data, rsa_key_file, signature, order='little'):
         if rsa_key.d:
             cmd = "openssl rsautl -verify -raw -inkey " + rsa_key_file
     except (AttributeError):
-        cmd = "openssl rsautl -verify -raw --pubin -inkey " + rsa_key_file
+        cmd = "openssl rsautl -verify -raw -pubin -inkey " + rsa_key_file
 
     p = subprocess.Popen(
         cmd,


### PR DESCRIPTION
The `openssl rsautl` command expects options with a single dash (not two).  Newer versions (1.1.1+) of openssl appear to handle two dashes for the `-pubin` option fine; however, older versions like 1.0.2k-fips are unable to handle this.


```
$ openssl rsautl -h
Usage: rsautl [options]
-in file        input file
-out file       output file
-inkey file     input key
-keyform arg    private key format - default PEM
-pubin          input is an RSA public
-certin         input is a certificate carrying an RSA public key
-ssl            use SSL v2 padding
-raw            use no padding
-pkcs           use PKCS#1 v1.5 padding (default)
-oaep           use PKCS#1 OAEP
-sign           sign with private key
-verify         verify with public key
-encrypt        encrypt with public key
-decrypt        decrypt with private key
-hexdump        hex dump output
-engine e       use engine e, possibly a hardware device.
-passin arg    pass phrase source
```