### PR TITLE
otptool: add no-pre-production flag

### DIFF
--- a/socsec/otptool.py
+++ b/socsec/otptool.py
@@ -1141,8 +1141,17 @@ class OTP(object):
             bytearray(scu_ignore.tobytes())
 
     def make_otp_image(self, config_file, key_folder,
-                       user_data_folder, output_folder, no_last_bit=False):
+                       user_data_folder, output_folder,
+                       no_last_bit=False, no_pre_production=False):
         otp_config = jstyleson.load(config_file)
+
+        if no_pre_production:
+            if otp_config['version'] in ['A0',
+                                         'A1',
+                                         'A2',
+                                         '1030A0',
+                                         '1030A1']:
+                raise OtpError('SOC version is incorrect in OTP config')
 
         if otp_config['version'] == 'A0':
             otp_info = self.otp_info.OTP_INFO['A0']
@@ -2037,6 +2046,10 @@ class otpTool(object):
                                 help='(develop)remove last bit in OTP header',
                                 action='store_true',
                                 required=False)
+        sub_parser.add_argument('--no_pre_production',
+                                help='check no pre production version',
+                                action='store_true',
+                                required=False)
         sub_parser.set_defaults(func=self.make_otp_image)
 
         sub_parser = subparsers.add_parser('print',
@@ -2063,7 +2076,8 @@ class otpTool(object):
                                 args.key_folder,
                                 args.user_data_folder,
                                 args.output_folder,
-                                args.no_last_bit)
+                                args.no_last_bit,
+                                args.no_pre_production)
 
     def print_otp_image(self, args):
         self.otp.print_otp_image(args.otp_image)


### PR DESCRIPTION
It helps to verify whether users set the correct SOC version in their providing OTP config.
For example:
AST2600 production version is A3.
If users set the SOC version is either “A2” or “A1” into their providing OTP config,
otptool will raise error and show the error message with this flag.
```
"version": "A1" or "version": "A2"
```

This request is asked from OpenBMC team(IBM), they decided to only support secure boot Root of Trust(RoT) for AST2600 A3.
This flag will help them to infer the A3 versus pre-A3 case.

By default, this flag status is “False” in otptool because ASPEED-BMC/openbmc should support all SOC versions.
This flag will only be added into Mainline OpenBMC because IBM decided to only support AST2600 A3 RoT.

Detail discussion here,
https://gerrit.openbmc-project.xyz/c/openbmc/openbmc/+/49789
https://gerrit.openbmc-project.xyz/c/openbmc/openbmc/+/50716

@amboar comment
```
It would be helpful if we could detect OTP configurations for A1/A2 and exit with an error message, but I'm not going to require it to submit what you've got here. With this we can start adding OTP configs to the tree, and that's a benefit for at least us at IBM. We might need some extra support from otptool to help with the error case (maybe a `--no-pre-production flag that makes otptool error out for pre-production configs?)
```
Signed-off-by: Jamin Lin <jamin_lin@aspeedtech.com>