### PR TITLE
otptool: Define value_start in `rev_id` path

### DIFF
--- a/socsec/otptool.py
+++ b/socsec/otptool.py
@@ -1039,6 +1039,7 @@ class OTP(object):
                 bit_offset = info['bit_offset']
                 offset = dw_offset*32 + bit_offset
                 bit_length = info['bit_length']
+                value_start = info['value_start']
                 offset_value = int(value, 16) - value_start
 
                 if offset_value < 0 or offset_value > bit_length:


### PR DESCRIPTION
Fixes:

```
Traceback (most recent call last):
  File "/usr/bin/otptool", line 29, in <module>
    tool.run(sys.argv)
  File "/usr/lib/python3.11/site-packages/socsec/otptool.py", line 2127, in run
    args.func(args)
  File "/usr/lib/python3.11/site-packages/socsec/otptool.py", line 2130, in make_otp_image
    self.otp.make_otp_image(args.config,
  File "/usr/lib/python3.11/site-packages/socsec/otptool.py", line 1335, in make_otp_image
    config_region, config_region_ignore = self.make_config_region(
                                          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/socsec/otptool.py", line 1042, in make_config_region
    offset_value = int(value, 16) - value_start
                                    ^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'value_start' where it is not associated with a value
```