### PR TITLE
socsec: fix verification of secure and OTP images compatibility

### DIFF
--- a/socsec/socsec.py
+++ b/socsec/socsec.py
@@ -1425,8 +1425,8 @@ class SecureBootVerify(object):
 
     def parse_config(self, soc_version, config_region):
         cfg0 = struct.unpack('<I', config_region[0:4])[0]
-        cfg3 = struct.unpack('<I', config_region[8:12])[0]
-        cfg4 = struct.unpack('<I', config_region[12:16])[0]
+        cfg3 = struct.unpack('<I', config_region[12:16])[0]
+        cfg4 = struct.unpack('<I', config_region[16:20])[0]
 
         sign_scheme = (cfg0 >> 10) & 0xf
         sb_mode = (cfg0 >> 7) & 0x1


### PR DESCRIPTION
Fix cfg3 and cfg4 computation when verifying secure and OTP images compatibility.

Tested with:

- Generating secure bl1 image with header offset set to 0x10:
```
socsec make_secure_bl1_image \
     --soc 2600 \
     --algorithm RSA4096_SHA512 \
     --rsa_sign_key tests/keys/rsa4096.pem \
     --bl1_image tests/data/bl1.bin \
     --output tmp/bl1.signed.bin \
     --header_offset=0x10
```

- Generating OTP image based on 2600-a3_mode2-rsa4096-sha512-little.json with header offset set to 0x10:
```
cat tests/otp/2600-a3_mode2-rsa4096-sha512-little.json
...
    "config_region": {
        "Secure Boot Mode": "Mode_2",
        "Secure crypto RSA length": "RSA4096",
        "Hash mode": "SHA512",
        "Enable image encryption": false,
        "Secure boot header offset": "0x10"
    },
...

otptool make_otp_image --key_folder tests/keys/ tests/otp/2600-a3_mode2-rsa4096-sha512-little.json --output_folder tmp
```

- Verifying secure and OTP images compatibility:
```
socsec verify --sec_image tmp/bl1.signed.bin --otp_image tmp/otp-all.image
Algorithm: RSA_SHA
RSA length: 4096
HASH length: 512
check RoT header PASS
Verify key ...
Key Type: OEM DSS RSA public keys
ID: 0
M:
00000000: 41 C0 57 A3 B4 FC 52 14  73 A0 DA 00 31 E7 E6 70  A.W...R.s...1..p
00000010: 78 AD 2E 3C 8C 0C 97 76  D2 37 C8 DE 89 95 40 C5  x..<...v.7....@.
00000020: 74 7B 61 52 E6 04 AF CE  82 CF 0A 27 50 32 B8 56  t{aR.......'P2.V
00000030: 50 88 C4 63 BC DA 4D 83  E6 75 5C 31 87 0B 27 76  P..c..M..u\1..'v
00000040: 14 DA 54 EA E7 45 29 C2  E7 04 82 FD 82 F3 FC 35  ..T..E)........5
00000050: 4E A1 A5 26 69 A3 B6 C5  7A 0F B2 D0 0B 71 F2 FC  N..&i...z....q..
00000060: C7 34 1E A6 B3 75 A6 92  C7 E5 AB 58 6E 8E 6F 0C  .4...u.....Xn.o.
00000070: 6D 94 2D 66 86 3D F3 46  32 74 E6 72 45 17 48 18  m.-f.=.F2t.rE.H.
00000080: 2D 98 5B AA B3 C8 78 05  A6 C2 97 97 A6 AE E3 E6  -.[...x.........
00000090: 38 4C 44 CA A0 83 12 BA  8B 19 EA 7B 46 59 43 EE  8LD........{FYC.
000000A0: 2C EE AC 2F EF 4F 95 B2  09 49 DA 61 60 D5 DB 1F  ,../.O...I.a`...
000000B0: E3 D3 5C 67 B6 33 9C 12  7A B6 84 5A 28 3A F0 F2  ..\g.3..z..Z(:..
000000C0: 29 AC A7 52 2F EF F8 5B  AD A9 7C FA FE 5F FA 7C  )..R/..[..|.._.|
000000D0: E0 90 2A 28 F9 74 6C F8  99 C5 9C A7 3B 41 54 B0  ..*(.tl.....;AT.
000000E0: 2C A0 55 D7 D0 29 21 0B  FD E4 B1 E4 CD 88 15 CB  ,.U..)!.........
000000F0: 5F A1 0F 3D 40 3B D0 E2  96 B1 EF B4 3D 90 B1 77  _..=@;......=..w
00000100: 8A ED 44 C9 8A 62 8A 08  B5 68 26 29 E9 F0 B5 31  ..D..b...h&)...1
00000110: B4 16 CC E8 C2 CF 8F 8B  48 9F 6B 12 6B 6B 97 26  ........H.k.kk.&
00000120: 13 DB DF 81 23 C6 04 5E  8C 4F 71 13 98 B7 65 11  ....#..^.Oq...e.
00000130: E0 69 56 84 02 3F 09 F7  06 C5 9C D1 A3 56 3A 75  .iV..?.......V:u
00000140: 82 1F 40 E8 47 72 83 5C  4A A9 2E 74 AD A2 5B 1E  ..@.Gr.\J..t..[.
00000150: 20 E2 FF 97 C5 D5 AF 97  27 4B DB A2 B2 A3 F5 20   .......'K.....
00000160: 05 69 76 25 74 B3 F4 E1  7D A6 A4 AC 4B EA C5 7A  .iv%t...}...K..z
00000170: 4A 3F 11 85 87 32 4E 1D  BE 56 65 E3 BE 78 10 68  J?...2N..Ve..x.h
00000180: E9 33 BC CF 37 EB 10 EB  1F 9F 6B A0 5B AC 73 9B  .3..7.....k.[.s.
00000190: 71 F0 94 59 14 5C 7B 8C  C2 FC B0 AB 11 B0 CE B5  q..Y.\{.........
000001A0: 3C CA E2 0E 5A 3D 1A 48  69 6B 69 B5 EF A6 65 75  <...Z=.Hiki...eu
000001B0: 11 B5 32 B3 F8 25 06 D8  C5 56 57 2A 42 96 68 43  ..2..%...VW*B.hC
000001C0: 0B 84 51 57 44 75 C4 33  61 E4 E6 E8 1B B3 74 C7  ..QWDu.3a.....t.
000001D0: 67 5D E4 C0 50 1F 8F 8D  74 F4 51 96 35 A4 CE C7  g]..P...t.Q.5...
000001E0: F0 02 D4 53 7E B6 FA FC  BB A8 BB BC A1 F7 56 29  ...S~.........V)
000001F0: E4 5F DC C1 04 D3 FA A7  3A 05 A5 57 B7 1E EA AB  ._......:..W....
E:
00000000: 01 00 01                                          ...
check RoT integrity PASS
```

Fixes #17