### PR TITLE
python: use importlib if available

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ coverage==5.3.1
 ecdsa==0.18.0
 xlrd==1.2.0
 cryptography==44.0.2
+importlib-resources; python_version < "3.9"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,7 @@
+try:
+    from importlib import resources as importlib_resources
+except ImportError:
+    import importlib_resources
 from socsec import __version__
 import setuptools
 

--- a/socsec/__init__.py
+++ b/socsec/__init__.py
@@ -21,7 +21,17 @@
 from bitarray import bitarray
 import os
 from ecdsa.keys import VerifyingKey
-from pkg_resources import resource_filename as pkgdata
+try:
+    from importlib import resources as importlib_resources
+except ImportError:
+    import importlib_resources
+
+def pkgdata(package, resource):
+    try:
+        return str(importlib_resources.files(package).joinpath(resource))
+    except AttributeError:
+        with importlib_resources.path(package, resource) as p:
+            return str(p)
 import struct
 from Crypto.PublicKey import RSA
 import binascii


### PR DESCRIPTION
pkg_resources is deprecated for newer versions of Python and is no
longer supported in the Python version (3.14) used by the latest
OpenEmbedded.

importlib has been available since 3.7 and is the recommended
replacement.  Use importlib instead when available.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
